### PR TITLE
Adds identify_testers to config block

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -36,6 +36,7 @@ SDK and be submitted to the TestFlight platform.
            app.testflight.api_token = '<insert your API token here>'
            app.testflight.team_token = '<insert your team token here>'
            app.testflight.notify = true # default is false
+           app.testflight.identify_testers = true # default is false
          end
        end
      end

--- a/lib/motion/project/testflight.rb
+++ b/lib/motion/project/testflight.rb
@@ -27,7 +27,7 @@ unless defined?(Motion::Project::Config)
 end
 
 class TestFlightConfig
-  attr_accessor :sdk, :api_token, :team_token, :distribution_lists, :notify
+  attr_accessor :sdk, :api_token, :team_token, :distribution_lists, :notify, :identify_testers
 
   def initialize(config)
     @config = config
@@ -48,6 +48,11 @@ class TestFlightConfig
     create_launcher
   end
 
+  def identify_testers=(identify_testers)
+    @identify_testers = identify_testers
+    create_launcher
+  end
+
   def inspect
     {:sdk => sdk, :api_token => api_token, :team_token => team_token, :distribution_lists => distribution_lists}.inspect
   end
@@ -61,6 +66,7 @@ class TestFlightConfig
 
 if Object.const_defined?('TestFlight') and !UIDevice.currentDevice.model.include?('Simulator')
   NSNotificationCenter.defaultCenter.addObserverForName(UIApplicationDidBecomeActiveNotification, object:nil, queue:nil, usingBlock:lambda do |notification|
+  #{'TestFlight.setDeviceIdentifier(UIDevice.currentDevice.uniqueIdentifier)' if identify_testers}
   TestFlight.takeOff('#{team_token}')
   end)
 end


### PR DESCRIPTION
This makes it possible to link crashes etc. to testers/devices in TestFlight.
