### PR TITLE
pass ENV['notify'] through to the curl call

### DIFF
--- a/lib/motion/project/testflight.rb
+++ b/lib/motion/project/testflight.rb
@@ -116,6 +116,8 @@ namespace 'testflight' do
     distribution_lists = (prefs.distribution_lists ? prefs.distribution_lists.join(',') : nil)
     notes = ENV['notes']
     App.fail "Submission notes must be provided via the `notes' environment variable. Example: rake testflight notes='w00t'" unless notes
+    
+    prefs.notify = true if ENV['notify']
 
     Rake::Task["archive"].invoke
   


### PR DESCRIPTION
i don't usually want to specify notify in the Rakefile, but as a build-time decision

rake testflight notes="hello world"                 #build and upload to testflight (defaults to no notification)
rake testflight notes="hello world" notify=1    #build and upload to testflight (notifying the group)
